### PR TITLE
Enable vhost-user ports on supported platforms.

### DIFF
--- a/networking_odl/common/cache.py
+++ b/networking_odl/common/cache.py
@@ -1,0 +1,109 @@
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import collections
+import six
+import sys
+import time
+
+
+class CacheEntry(collections.namedtuple('CacheEntry', ['timeout', 'value'])):
+
+    def is_expired(self, current_clock):
+        return self.timeout < current_clock
+
+
+class Cache(object):
+
+    def __init__(self, fetch_all_func):
+        if not callable(fetch_all_func):
+            message = 'Expected callable as parameter, got {!r}.'.format(
+                fetch_all_func)
+            raise TypeError(message)
+        self._fetch_all = fetch_all_func
+        self._entries = {}
+
+    new_entry = CacheEntry
+
+    def fetch(self, key, timeout):
+        _, value = self.fetch_any([key], timeout=timeout)
+        return value
+
+    def fetch_any(self, keys, timeout):
+        return next(self.fetch_all(keys=keys, timeout=timeout))
+
+    def fetch_all(self, keys, timeout):
+        current_clock = time.clock()
+        missing_keys = []
+        cause_exc_info = None
+        for key in keys:
+            entry = self._entries.get(key, None)
+            if not entry or entry.is_expired(current_clock):
+                # This has to be fetched
+                missing_keys.append(key)
+
+            else:
+                # Yield existing entry
+                yield key, entry.value
+
+        if missing_keys:
+            # Fetch more entries and update the cache
+            try:
+                new_entries_timeout = current_clock + timeout
+                for key, value in self._fetch_all(tuple(missing_keys)):
+                    entry = self.new_entry(new_entries_timeout, value)
+                    self._entries[key] = entry
+
+            # pylint: disable=broad-except
+            except Exception:
+                cause_exc_info = sys.exc_info()
+
+            # yield new or expired entries
+            for key in tuple(missing_keys):
+                entry = self._entries.get(key, None)
+                if entry:
+                    missing_keys.remove(key)
+                    yield key, entry.value
+
+            if missing_keys:
+                if not cause_exc_info:
+                    try:
+                        raise KeyError(
+                            'Invalid keys: {!r}'.format(missing_keys))
+
+                    except KeyError:
+                        cause_exc_info = sys.exc_info()
+
+                raise CacheFetchError(
+                    missing_keys=missing_keys,
+                    cause_exc_info=sys.exc_info())
+
+    def clear(self):
+        entries = self._entries
+        self._entries = {}
+        return entries
+
+
+class CacheFetchError(KeyError):
+
+    missing_keys = tuple()
+
+    def __init__(self, missing_keys, cause_exc_info):
+        super(CacheFetchError, self).__init__(str(cause_exc_info[0]))
+        self.cause_exc_info = cause_exc_info
+        self.missing_keys = missing_keys
+
+    def reraise_cause(self):
+        exc_info = self.cause_exc_info
+        six.reraise(*exc_info)

--- a/networking_odl/common/utils.py
+++ b/networking_odl/common/utils.py
@@ -13,6 +13,14 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
+import socket
+
+from oslo_log import log as logging
+
+from networking_odl.common import cache
+
+LOG = logging.getLogger(__name__)
+
 
 def try_del(d, keys):
     """Ignore key errors when deleting from a dictionary."""
@@ -21,3 +29,34 @@ def try_del(d, keys):
             del d[key]
         except KeyError:
             pass
+
+
+def _get_addresses_by_name(name):
+    for name in name:
+        # a set is used because this could contains duplicates
+        addresses = {i[4][0] for i in socket.getaddrinfo(name, None)}
+
+        # The value is stored in the cache before it is returned. The value is
+        # translated to a tuple (instead of a list) to avoid being changed by
+        # the caller. The tuple is sorted to make the result more predictable
+        # as we do not have control over the order getaddrinfo and set sequence
+        # yield values.
+        yield name, tuple(sorted(addresses))
+
+
+_addresses_by_name_cache = cache.Cache(_get_addresses_by_name)
+
+
+def get_addresses_by_name(name, time_to_live=60.0):
+    """Gets and caches addresses for given name.
+
+    This is a cached wrapper for function 'socket.getaddrinfo'.
+
+    :returns: a sequence of unique addresses binded to given hostname.
+    """
+
+    try:
+        return _addresses_by_name_cache.fetch(name, timeout=time_to_live)
+
+    except cache.CacheFetchError as error:
+        error.reraise_cause()

--- a/networking_odl/ml2/mech_driver.py
+++ b/networking_odl/ml2/mech_driver.py
@@ -21,13 +21,11 @@ from oslo_log import log as logging
 from oslo_utils import excutils
 import requests
 
-from neutron.common import constants as n_const
 from neutron.common import exceptions as n_exc
 from neutron.common import utils
 from neutron import context as neutron_context
 from neutron.extensions import portbindings
 from neutron.extensions import securitygroup as sg
-from neutron.plugins.common import constants
 from neutron.plugins.ml2 import driver_api
 from neutron.plugins.ml2 import driver_context
 
@@ -35,10 +33,12 @@ from networking_odl.common import callback as odl_call
 from networking_odl.common import client as odl_client
 from networking_odl.common import constants as odl_const
 from networking_odl.common import utils as odl_utils
+from networking_odl.ml2 import network_topology
 from networking_odl.openstack.common._i18n import _LE
 
 
 cfg.CONF.import_group('ml2_odl', 'networking_odl.common.config')
+
 LOG = logging.getLogger(__name__)
 
 not_found_exception_map = {odl_const.ODL_NETWORKS: n_exc.NetworkNotFound,
@@ -206,6 +206,8 @@ class OpenDaylightDriver(object):
         self.client = odl_client.OpenDaylightRestClient.create_client()
         self.sec_handler = odl_call.OdlSecurityGroupsHandler(self)
         self.vif_details = {portbindings.CAP_PORT_FILTER: True}
+        self._network_topology = network_topology.NetworkTopology(
+            vif_details=self.vif_details)
 
     def synchronize(self, operation, object_type, context):
         """Synchronize ODL with Neutron following a configuration change."""
@@ -337,48 +339,10 @@ class OpenDaylightDriver(object):
                 self.out_of_sync = True
 
     def bind_port(self, port_context):
-        """Set binding for all valid segments
+        """Set binding for valid segment
 
         """
-
-        valid_segment = None
-        for segment in port_context.segments_to_bind:
-            if self._check_segment(segment):
-                valid_segment = segment
-                break
-
-        if valid_segment:
-            vif_type = self._get_vif_type(port_context)
-            LOG.debug("Bind port %(port)s on network %(network)s with valid "
-                      "segment %(segment)s and VIF type %(vif_type)r.",
-                      {'port': port_context.current['id'],
-                       'network': port_context.network.current['id'],
-                       'segment': valid_segment, 'vif_type': vif_type})
-
-            port_context.set_binding(
-                segment[driver_api.ID], vif_type,
-                self.vif_details,
-                status=n_const.PORT_STATUS_ACTIVE)
-
-    def _check_segment(self, segment):
-        """Verify a segment is valid for the OpenDaylight MechanismDriver.
-
-        Verify the requested segment is supported by ODL and return True or
-        False to indicate this to callers.
-        """
-
-        network_type = segment[driver_api.NETWORK_TYPE]
-        return network_type in [constants.TYPE_LOCAL, constants.TYPE_GRE,
-                                constants.TYPE_VXLAN, constants.TYPE_VLAN]
-
-    def _get_vif_type(self, port_context):
-        """Get VIF type string for given PortContext
-
-        Dummy implementation: it always returns following constant.
-        neutron.extensions.portbindings.VIF_TYPE_OVS
-        """
-
-        return portbindings.VIF_TYPE_OVS
+        self._network_topology.bind_port(port_context)
 
 
 class OpenDaylightMechanismDriver(driver_api.MechanismDriver):

--- a/networking_odl/ml2/network_topology.py
+++ b/networking_odl/ml2/network_topology.py
@@ -1,0 +1,301 @@
+# Copyright (c) 2013-2014 OpenStack Foundation
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import collections
+import copy
+import os
+
+import requests
+from six.moves.urllib import parse as urlparse
+
+from neutron.common import constants as n_const
+from neutron.extensions import portbindings
+from neutron.plugins.common import constants
+from neutron.plugins.ml2 import driver_api
+from oslo_config import cfg
+from oslo_log import log as logging
+from oslo_serialization import jsonutils
+
+from networking_odl.common import cache
+from networking_odl.common import utils
+from networking_odl.openstack.common._i18n import _LE
+from networking_odl.openstack.common._i18n import _LI
+from networking_odl.openstack.common._i18n import _LW
+
+
+LOG = logging.getLogger(__name__)
+
+
+# default location for vhostuser sockets
+VHOSTUSER_SOCKET_DIR = '/var/run/openvswitch'
+
+# prefix for ovs port
+PORT_PREFIX = 'vhu'
+
+
+_GET_ODL_NETWORK_TOPOLOGY_URL =\
+    'restconf/operational/network-topology:network-topology/'
+
+
+class NetworkTopology(object):
+
+    def __init__(self, vif_details=None, client=None):
+        self._vif_details = vif_details or {}
+        self._client = client
+
+        # Tables of NetworkTopologyElement
+        self._elements_by_ip = cache.Cache(self._fetch_topology_from_odl)
+
+    @property
+    def client(self):
+        client = self._client
+        if not client:
+            self._client = client = NetworkTopologyClient.from_configuration()
+        return client
+
+    def bind_port(self, port_context):
+        """Set binding for valid segment
+
+        """
+
+        # Bind port to the first valid segment
+        for segment in port_context.segments_to_bind:
+            if self._is_valid_segment(segment):
+                # Guest best VIF type for given host
+                vif_type = self._get_vif_type(port_context.host)
+                vif_details = self._get_vif_details(
+                    port_context.current['id'], vif_type)
+                LOG.debug(
+                    'Bind port with valid segment:\n'
+                    '\tport: %(port)r\n'
+                    '\tnetwork: %(network)r\n'
+                    '\tsegment: %(segment)r\n'
+                    '\tVIF type: %(vif_type)r\n'
+                    '\tVIF details: %(vif_details)r',
+                    {'port': port_context.current['id'],
+                     'network': port_context.network.current['id'],
+                     'segment': segment, 'vif_type': vif_type,
+                     'vif_details': vif_details})
+                port_context.set_binding(
+                    segment[driver_api.ID], vif_type, vif_details,
+                    status=n_const.PORT_STATUS_ACTIVE)
+                break
+
+        else:
+            LOG.warning(
+                _LW('No such valid segment for binding given port:\n'
+                    '\tport: %(port)r\n'
+                    '\tnetwork: %(network)r\n'),
+                {'port': port_context.current['id'],
+                 'network': port_context.network.current['id']})
+
+    def _is_valid_segment(self, segment):
+        """Verify a segment is valid for the OpenDaylight MechanismDriver.
+
+        Verify the requested segment is supported by ODL and return True or
+        False to indicate this to callers.
+        """
+
+        network_type = segment[driver_api.NETWORK_TYPE]
+        return network_type in [constants.TYPE_LOCAL, constants.TYPE_GRE,
+                                constants.TYPE_VXLAN, constants.TYPE_VLAN]
+
+    def _get_vif_type(self, host_name):
+        """Get VIF type string for given PortContext
+
+        Dummy implementation: it always returns following constant.
+        neutron.extensions.portbindings.VIF_TYPE_OVS
+        """
+        # pylint: disable=broad-except
+
+        vif_type = portbindings.VIF_TYPE_OVS
+
+        try:
+            element = self._fetch_element_by_host(host_name)
+            vif_type = element.vif_type
+
+        except Exception:
+            LOG.exception(_LE('Unable to detect VIF type.'))
+
+        return vif_type
+
+    def _get_vif_details(self, port_context_id, vif_type):
+        vif_details = copy.copy(self._vif_details)
+        if vif_type == portbindings.VIF_TYPE_VHOST_USER:
+            socket_path = os.path.join(
+                VHOSTUSER_SOCKET_DIR, (PORT_PREFIX + port_context_id)[:14])
+
+            vif_details.update({
+                portbindings.VHOST_USER_MODE:
+                portbindings.VHOST_USER_MODE_CLIENT,
+                portbindings.VHOST_USER_OVS_PLUG: True,
+                portbindings.VHOST_USER_SOCKET: socket_path
+            })
+        return vif_details
+
+    def _fetch_element_by_host(self, host_name, cache_timeout=60.0):
+        host_ips = utils.get_addresses_by_name(host_name)
+        try:
+            _, element = self._elements_by_ip.fetch_any(
+                host_ips, cache_timeout)
+
+        except cache.CacheFetchError as error:
+            LOG.error(
+                _LE('Error getting network topology for hostname '
+                    '%(host_name)r.'),
+                {'host_name': host_name},
+                exc_info=error.cause_exc_info)
+            error.reraise_cause()
+
+        return element
+
+    def _fetch_topology_from_odl(self, ips):
+        # pylint: disable=unused-argument
+        LOG.info(_LI('Fetch network topology from ODL.'))
+        response = self.client.get(_GET_ODL_NETWORK_TOPOLOGY_URL)
+
+        json_network_topology = response.json()
+        if LOG.isEnabledFor(logging.logging.DEBUG):
+            topology_str = jsonutils.dumps(
+                json_network_topology, sort_keys=True, indent=4,
+                separators=(',', ': '))
+            LOG.debug("Got network topology:\n%s", topology_str)
+
+        return _parse_network_topology(json_network_topology)
+
+
+class NetworkTopologyClient(object):
+
+    def __init__(self, base_url, username, password, timeout):
+        self.base_url = base_url
+        self.auth = (username, password)
+        self.timeout = timeout
+
+    @classmethod
+    def from_configuration(cls):
+        # Parse connection configuration
+        url = urlparse.urlparse(cfg.CONF.ml2_odl.url)
+        port = ''
+        if url.port:
+            port = ':' + str(url.port)
+        base_url = '{}://{}{}/'.format(url.scheme, url.hostname, port)
+
+        return cls(
+            base_url=base_url,
+            username=cfg.CONF.ml2_odl.username,
+            password=cfg.CONF.ml2_odl.password,
+            timeout=cfg.CONF.ml2_odl.timeout)
+
+    def get(self, full_path, data=None):
+        return self.request('GET', full_path, data)
+
+    def request(self, method, full_path, data=None):
+        headers = {'Content-Type': 'application/json'}
+        url = self.base_url + full_path
+        LOG.debug("Sending METHOD (%(method)s) URL (%(url)s) JSON (%(data)s)",
+                  {'method': method, 'url': url, 'data': data})
+        response = requests.request(
+            method=method, url=url, headers=headers, data=data, auth=self.auth,
+            timeout=self.timeout)
+        response.raise_for_status()
+        return response
+
+
+def _parse_network_topology(network_topologies):
+    elements_by_uuid = collections.defaultdict(NetworkTopologyElement)
+
+    for topology in network_topologies[
+            'network-topology']['topology']:
+        if topology['topology-id'].startswith('ovsdb:'):
+            for node in topology['node']:
+                # expected url format: ovsdb://uuid/<uuid>[/<path>]]
+                node_url = urlparse.urlparse(node['node-id'])
+                if node_url.scheme == 'ovsdb'\
+                        and node_url.netloc == 'uuid':
+                    # split_res = ['', '<uuid>', '<path>']
+                    split_res = node_url.path.split('/', 2)
+
+                    # uuid is used to identify nodes referring to the same
+                    # element
+                    uuid = split_res[1]
+                    element = elements_by_uuid[uuid]
+
+                    # inner_path can be [] or [<path>]
+                    inner_path = split_res[2:]
+                    _update_element_from_json_ovsdb_topology_node(
+                        node, element, uuid, *inner_path)
+
+    # Yield results always in the same order to enforce reliability:
+    # the order of parsed topology nodes yields same elements in the same
+    # order
+    for uuid in sorted(elements_by_uuid):
+        element = elements_by_uuid[uuid]
+        yield element.remote_ip, element
+
+
+def _update_element_from_json_ovsdb_topology_node(
+        node, element, uuid, path=None):
+
+    if not path:
+        # global element section (root path)
+
+        # fetch remote IP address
+        element.remote_ip = node["ovsdb:connection-info"]["remote-ip"]
+
+        for vif_type_entry in node.get(
+                "ovsdb:interface-type-entry", []):
+            if vif_type_entry.get("interface-type", None) ==\
+                    "ovsdb:interface-type-dpdkvhostuser":
+                element.support_vhost_user = True
+                break
+
+        else:
+            LOG.debug(
+                'Interface type not found in network topology node %r.', uuid)
+
+        LOG.debug(
+            'Topology element updated:\n'
+            ' - uuid: %(uuid)r\n'
+            ' - remote_ip: %(remote_ip)r\n'
+            ' - support_vhost_user: %(support_vhost_user)r',
+            {'uuid': uuid,
+             'remote_ip': element.remote_ip,
+             'support_vhost_user': element.support_vhost_user})
+
+    elif path == 'bridge/br-int':
+        datapath_type = node.get("ovsdb:datapath-type")
+        if datapath_type == "ovsdb:datapath-type-netdev":
+            element.has_datapath_type_netdev = True
+            LOG.debug(
+                'Topology element updated:\n'
+                ' - uuid: %(uuid)r\n'
+                ' - has_datapath_type_netdev: %(has_datapath_type_netdev)r',
+                {'uuid': uuid,
+                 'has_datapath_type_netdev': element.has_datapath_type_netdev})
+
+
+class NetworkTopologyElement(object):
+
+    remote_ip = None  # it can be None or a string
+    has_datapath_type_netdev = False  # it can be False or True
+    support_vhost_user = False  # it can be False or True
+
+    @property
+    def vif_type(self):
+        if self.has_datapath_type_netdev and self.support_vhost_user:
+            return portbindings.VIF_TYPE_VHOST_USER
+
+        else:
+            return portbindings.VIF_TYPE_OVS

--- a/networking_odl/tests/unit/common/test_cache.py
+++ b/networking_odl/tests/unit/common/test_cache.py
@@ -1,0 +1,210 @@
+# Copyright (c) 2015 OpenStack Foundation
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+import mock
+
+from networking_odl.common import cache
+import unittest
+
+
+class TestCache(unittest.TestCase):
+
+    def test_init_with_callable(self):
+
+        def given_fetch_method():
+            pass
+
+        cache.Cache(given_fetch_method)
+
+    def test_init_without_callable(self):
+        self.assertRaises(TypeError, lambda: cache.Cache(object()))
+
+    def test_fecth_once(self):
+        value = 'value'
+
+        given_fetch_method = mock.Mock(return_value=iter([('key', value)]))
+        given_cache = cache.Cache(given_fetch_method)
+
+        # When value with key is fetched
+        result = given_cache.fetch('key', 60.0)
+
+        # Result is returned
+        self.assertIs(value, result)
+
+        # Then fetch method is called once
+        given_fetch_method.assert_called_once_with(('key',))
+
+    def test_fecth_with_no_result(self):
+        given_fetch_method = mock.Mock(return_value=iter([]))
+        given_cache = cache.Cache(given_fetch_method)
+
+        # When value with key is fetched
+        try:
+            given_cache.fetch('key', 60.0)
+
+        except cache.CacheFetchError as error:
+            given_fetch_method.assert_called_once_with(('key',))
+            self.assertRaises(KeyError, error.reraise_cause)
+
+        else:
+            self.fail('Expecting CacheFetchError to be raised.')
+
+    def test_fecth_with_failure(self):
+        # pylint: disable=unused-argument
+
+        def failing_function(keys):
+            raise RuntimeError
+
+        given_fetch_method = mock.Mock(side_effect=failing_function)
+        given_cache = cache.Cache(given_fetch_method)
+
+        # When value with key is fetched
+        try:
+            given_cache.fetch('key', 60.0)
+
+        except cache.CacheFetchError as error:
+            given_fetch_method.assert_called_once_with(('key',))
+            self.assertRaises(RuntimeError, error.reraise_cause)
+
+        else:
+            self.fail('Expecting CacheFetchError to be raised.')
+
+    def test_fecth_again_after_clear(self):
+        value1 = 'value1'
+        value2 = 'value2'
+        given_fetch_method = mock.Mock(
+            side_effect=[iter([('key', value1)]),
+                         iter([('key', value2)])])
+        given_cache = cache.Cache(given_fetch_method)
+
+        # When value with key is fetched
+        result1 = given_cache.fetch('key', 60.0)
+
+        # When cache is cleared
+        given_cache.clear()
+
+        # When value with same key is fetched again
+        result2 = given_cache.fetch('key', 0.0)
+
+        # Then first result is returned
+        self.assertIs(value1, result1)
+
+        # Then fetch method is called twice
+        self.assertEqual(
+            [mock.call(('key',)), mock.call(('key',))],
+            given_fetch_method.mock_calls)
+
+        # Then second result is returned
+        self.assertIs(value2, result2)
+
+    def test_fecth_again_before_timeout(self):
+        value1 = 'value1'
+        value2 = 'value2'
+        given_fetch_method = mock.Mock(
+            side_effect=[iter([('key', value1)]),
+                         iter([('key', value2)])])
+        given_cache = cache.Cache(given_fetch_method)
+
+        # When value with key is fetched
+        result1 = given_cache.fetch('key', 1.0)
+
+        # When value with same key is fetched again and cached entry is not
+        # expired
+        result2 = given_cache.fetch('key', 0.0)
+
+        # First result is returned
+        self.assertIs(value1, result1)
+
+        # Then fetch method is called once
+        given_fetch_method.assert_called_once_with(('key',))
+
+        # Then first result is returned twice
+        self.assertIs(value1, result2)
+
+    def test_fecth_again_after_timeout(self):
+        value1 = 'value1'
+        value2 = 'value2'
+        given_fetch_method = mock.Mock(
+            side_effect=[iter([('key', value1)]),
+                         iter([('key', value2)])])
+        given_cache = cache.Cache(given_fetch_method)
+
+        # When value with key is fetched
+        result1 = given_cache.fetch('key', 0.0)
+
+        # When value with same key is fetched again and cached entry is
+        # expired
+        result2 = given_cache.fetch('key', 0.0)
+
+        # Then first result is returned
+        self.assertIs(value1, result1)
+
+        # Then fetch method is called twice
+        self.assertEqual(
+            [mock.call(('key',)), mock.call(('key',))],
+            given_fetch_method.mock_calls)
+
+        # Then second result is returned
+        self.assertIs(value2, result2)
+
+    def test_fecth_two_values_yielding_both_before_timeout(self):
+        value1 = 'value1'
+        value2 = 'value2'
+        given_fetch_method = mock.Mock(
+            return_value=iter([('key1', value1),
+                               ('key2', value2)]))
+        given_cache = cache.Cache(given_fetch_method)
+
+        # When value with key is fetched
+        result1 = given_cache.fetch('key1', 60.0)
+
+        # When value with another key is fetched and cached entry is not
+        # expired
+        result2 = given_cache.fetch('key2', 60.0)
+
+        # Then first result is returned
+        self.assertIs(value1, result1)
+
+        # Then fetch method is called once
+        given_fetch_method.assert_called_once_with(('key1',))
+
+        # Then second result is returned
+        self.assertIs(value2, result2)
+
+    def test_fecth_two_values_yielding_both_after_timeout(self):
+        value1 = 'value1'
+        value2 = 'value2'
+        given_fetch_method = mock.Mock(
+            return_value=iter([('key1', value1),
+                               ('key2', value2)]))
+        given_cache = cache.Cache(given_fetch_method)
+
+        # When value with key is fetched
+        result1 = given_cache.fetch('key1', 0.0)
+
+        # When value with another key is fetched and cached entry is
+        # expired
+        result2 = given_cache.fetch('key2', 0.0)
+
+        # Then first result is returned
+        self.assertIs(value1, result1)
+
+        # Then fetch method is called twice
+        self.assertEqual(
+            [mock.call(('key1',)), mock.call(('key2',))],
+            given_fetch_method.mock_calls)
+
+        # Then second result is returned
+        self.assertIs(value2, result2)

--- a/networking_odl/tests/unit/common/test_utils.py
+++ b/networking_odl/tests/unit/common/test_utils.py
@@ -1,0 +1,146 @@
+# Copyright (c) 2015 OpenStack Foundation
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+
+import mock
+
+from neutron.tests import base
+
+from networking_odl.common import utils
+
+
+class TestGetAddressesByName(base.DietTestCase):
+
+    # pylint: disable=protected-access, unused-argument
+
+    def setUp(self):
+        super(TestGetAddressesByName, self).setUp()
+        self.clear_cache()
+        self.addCleanup(self.clear_cache)
+        time = self.patch(
+            utils.cache, 'time', clock=mock.Mock(return_value=0.0))
+        self.clock = time.clock
+        socket = self.patch(utils, 'socket')
+        self.getaddrinfo = socket.getaddrinfo
+
+    def patch(self, target, name, *args, **kwargs):
+        context = mock.patch.object(target, name, *args, **kwargs)
+        mocked = context.start()
+        self.addCleanup(context.stop)
+        return mocked
+
+    def clear_cache(self):
+        utils._addresses_by_name_cache.clear()
+
+    def test_get_addresses_by_valid_name(self):
+        self.getaddrinfo.return_value = [
+            (2, 1, 6, '', ('127.0.0.1', 0)),
+            (2, 2, 17, '', ('127.0.0.1', 0)),
+            (2, 3, 0, '', ('127.0.0.1', 0)),
+            (2, 1, 6, '', ('10.237.214.247', 0)),
+            (2, 2, 17, '', ('10.237.214.247', 0)),
+            (2, 3, 0, '', ('10.237.214.247', 0))]
+
+        # When valid host name is requested
+        result = utils.get_addresses_by_name('some_host_name')
+
+        # Then correct addresses are returned
+        self.assertEqual(('10.237.214.247', '127.0.0.1'), result)
+
+        # Then fetched addresses are cached
+        self.assertIs(result, utils.get_addresses_by_name('some_host_name'))
+
+        # Then addresses are fetched only once
+        self.getaddrinfo.assert_called_once_with('some_host_name', None)
+
+    def test_get_addresses_by_valid_name_when_cache_expires(self):
+        self.getaddrinfo.return_value = [
+            (2, 1, 6, '', ('127.0.0.1', 0)),
+            (2, 2, 17, '', ('127.0.0.1', 0)),
+            (2, 3, 0, '', ('127.0.0.1', 0)),
+            (2, 1, 6, '', ('10.237.214.247', 0)),
+            (2, 2, 17, '', ('10.237.214.247', 0)),
+            (2, 3, 0, '', ('10.237.214.247', 0))]
+
+        # When valid host name is requested
+        result1 = utils.get_addresses_by_name('some_host_name')
+
+        # and after a long time
+        self.clock.return_value = 1.0e6
+
+        # When valid host name is requested
+        result2 = utils.get_addresses_by_name('some_host_name')
+
+        # Then correct addresses are returned
+        self.assertEqual(('10.237.214.247', '127.0.0.1'), result1)
+        self.assertEqual(('10.237.214.247', '127.0.0.1'), result2)
+
+        # Then addresses are fetched only once
+        self.getaddrinfo.assert_has_calls(
+            [mock.call('some_host_name', None),
+             mock.call('some_host_name', None)])
+
+    def test_get_addresses_by_invalid_name(self):
+
+        # Given addresses resolution is failing
+        def failing_getaddrinfo(name, service):
+            raise RuntimeError()
+
+        self.getaddrinfo.side_effect = failing_getaddrinfo
+
+        # When invalid name is requested
+        self.assertRaises(
+            RuntimeError, utils.get_addresses_by_name, 'some_host_name')
+
+        # When invalid name is requested again
+        self.assertRaises(
+            RuntimeError, utils.get_addresses_by_name, 'some_host_name')
+
+        # Then result is fetched more times
+        self.getaddrinfo.assert_has_calls(
+            [mock.call('some_host_name', None),
+             mock.call('some_host_name', None)])
+
+    def test_get_addresses_failing_when_expired_in_cache(self):
+        self.getaddrinfo.return_value = [
+            (2, 1, 6, '', ('127.0.0.1', 0)),
+            (2, 2, 17, '', ('127.0.0.1', 0)),
+            (2, 3, 0, '', ('127.0.0.1', 0)),
+            (2, 1, 6, '', ('10.237.214.247', 0)),
+            (2, 2, 17, '', ('10.237.214.247', 0)),
+            (2, 3, 0, '', ('10.237.214.247', 0))]
+
+        # Given valid result is in chache but expired
+        given_previous_result = utils.get_addresses_by_name('some_host_name')
+        self.clock.return_value = 1.0e6
+
+        # Given addresses resolution is now failing
+        def failing_getaddrinfo(name, service):
+            raise RuntimeError()
+
+        self.getaddrinfo.side_effect = failing_getaddrinfo
+
+        result = utils.get_addresses_by_name('some_host_name')
+
+        # Then correct addresses are returned
+        self.assertEqual(('10.237.214.247', '127.0.0.1'), result)
+
+        # Then fetched addresses are the same expired ones
+        self.assertIs(given_previous_result, result)
+
+        # Then result is fetched more times
+        self.getaddrinfo.assert_has_calls(
+            [mock.call('some_host_name', None),
+             mock.call('some_host_name', None)])

--- a/networking_odl/tests/unit/ml2/test_driver.py
+++ b/networking_odl/tests/unit/ml2/test_driver.py
@@ -88,7 +88,7 @@ class TestODLShim(test_plugin.Ml2PluginV2TestCase):
         # given front-end with attached back-end
         front_end = self.driver
         front_end.odl_drv = back_end = mock.MagicMock(
-            spec=driver.OpenDaylightMechanismDriver)
+            spec=driver.OpenDaylightDriver)
         # given PortContext to be forwarded to back-end without using
         context = object()
 

--- a/networking_odl/tests/unit/ml2/test_mechanism_odl.py
+++ b/networking_odl/tests/unit/ml2/test_mechanism_odl.py
@@ -34,6 +34,7 @@ from neutron.tests import base
 from neutron.tests.unit.plugins.ml2 import test_plugin
 from neutron.tests.unit import testlib_api
 
+
 cfg.CONF.import_group('ml2_odl', 'networking_odl.common.config')
 
 
@@ -463,7 +464,7 @@ class OpenDaylightMechanismDriverTestCase(base.BaseTestCase):
             self.assertEqual(tenant_id, port['tenant_id'])
 
 
-class TestOpenDaylightDriver(base.DietTestCase):
+class TestOpenDaylightMechanismDriver(base.DietTestCase):
 
     # given valid  and invalid segments
     valid_segment = {
@@ -478,75 +479,21 @@ class TestOpenDaylightDriver(base.DietTestCase):
         api.SEGMENTATION_ID: 'API_SEGMENTATION_ID',
         api.PHYSICAL_NETWORK: 'API_PHYSICAL_NETWORK'}
 
-    @mock.patch.object(client, 'cfg')
-    def test_get_vif_type(self, cfg):
-        given_port_context = mock.MagicMock(spec=api.PortContext)
-        given_back_end = mech_driver.OpenDaylightDriver()
-
-        # when getting VIF type
-        vif_type = given_back_end._get_vif_type(given_port_context)
-
-        # then VIF type is ovs
-        self.assertIs(vif_type, portbindings.VIF_TYPE_OVS)
-
-    def test_check_segment(self):
-        """Validate the _check_segment method."""
-
-        # given driver and all network types
-        given_back_end = mech_driver.OpenDaylightDriver()
-        all_network_types = [constants.TYPE_FLAT, constants.TYPE_GRE,
-                             constants.TYPE_LOCAL, constants.TYPE_VXLAN,
-                             constants.TYPE_VLAN, constants.TYPE_NONE]
-
-        # when checking segments network type
-        valid_types = {
-            network_type
-            for network_type in all_network_types
-            if given_back_end._check_segment({api.NETWORK_TYPE: network_type})}
-
-        # then true is returned only for valid network types
-        self.assertEqual({
-            constants.TYPE_LOCAL, constants.TYPE_GRE, constants.TYPE_VXLAN,
-            constants.TYPE_VLAN}, valid_types)
-
     def test_bind_port_front_end(self):
         given_front_end = mech_driver.OpenDaylightMechanismDriver()
-        if hasattr(given_front_end, 'check_segment'):
-            self.skip(
-                "Old version of driver front-end doesn't delegate bind_port to"
-                " back-end.")
-
         given_vif_type = "MY_VIF_TYPE"
         given_port_context = self.given_port_context()
         given_back_end = mech_driver.OpenDaylightDriver()
-        given_back_end._get_vif_type = mock.Mock(return_value=given_vif_type)
+        given_back_end._network_topology._get_vif_type = mock.Mock(
+            return_value=given_vif_type)
         given_front_end.odl_drv = given_back_end
 
         # when port is bound
         given_front_end.bind_port(given_port_context)
 
         # then vif type is got calling _get_vif_type
-        given_back_end._get_vif_type.assert_called_once_with(
-            given_port_context)
-
-        # then context binding is setup wit returned vif_type and valid
-        # segment api ID
-        given_port_context.set_binding.assert_called_once_with(
-            self.valid_segment[api.ID], given_vif_type,
-            given_back_end.vif_details, status=n_constants.PORT_STATUS_ACTIVE)
-
-    def test_bind_port_back_end(self):
-        given_vif_type = "MY_VIF_TYPE"
-        given_port_context = self.given_port_context()
-        given_back_end = mech_driver.OpenDaylightDriver()
-        given_back_end._get_vif_type = mock.Mock(return_value=given_vif_type)
-
-        # when port is bound
-        given_back_end.bind_port(given_port_context)
-
-        # then vif type is got calling _get_vif_type
-        given_back_end._get_vif_type.assert_called_once_with(
-            given_port_context)
+        given_back_end._network_topology._get_vif_type.assert_called_once_with(
+            given_port_context.host)
 
         # then context binding is setup wit returned vif_type and valid
         # segment api ID

--- a/networking_odl/tests/unit/ml2/test_networking_topology.py
+++ b/networking_odl/tests/unit/ml2/test_networking_topology.py
@@ -1,0 +1,434 @@
+# Copyright (c) 2015 OpenStack Foundation
+# All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
+
+from os import path
+
+import mock
+from oslo_log import log as logging
+from oslo_serialization import jsonutils
+import requests
+
+from neutron.common import constants as n_constants
+from neutron.extensions import portbindings
+from neutron.plugins.common import constants
+from neutron.plugins.ml2 import driver_api as api
+from neutron.plugins.ml2 import driver_context
+from neutron.tests import base
+
+from networking_odl.ml2 import mech_driver
+from networking_odl.ml2 import network_topology
+
+
+LOG = logging.getLogger(__name__)
+
+
+class TestNetworkingTopology(base.DietTestCase):
+
+    # pylint: disable=protected-access
+
+    # given valid  and invalid segments
+    valid_segment = {
+        api.ID: 'API_ID',
+        api.NETWORK_TYPE: constants.TYPE_LOCAL,
+        api.SEGMENTATION_ID: 'API_SEGMENTATION_ID',
+        api.PHYSICAL_NETWORK: 'API_PHYSICAL_NETWORK'}
+
+    invalid_segment = {
+        api.ID: 'API_ID',
+        api.NETWORK_TYPE: constants.TYPE_NONE,
+        api.SEGMENTATION_ID: 'API_SEGMENTATION_ID',
+        api.PHYSICAL_NETWORK: 'API_PHYSICAL_NETWORK'}
+
+    segments_to_bind = [valid_segment, invalid_segment]
+
+    def setUp(self):
+        super(TestNetworkingTopology, self).setUp()
+        self.patch(network_topology.LOG, 'isEnabledFor', lambda level: True)
+
+    def test_fetch_element_with_no_entry(self):
+        given_client = self.mock_client('topology_without_vhost_user')
+        self.mock_get_addresses_by_name(['192.168.0.1'])
+        given_network_topology = network_topology.NetworkTopology(
+            client=given_client)
+
+        self.assertRaises(
+            KeyError,
+            lambda: given_network_topology._fetch_element_by_host(
+                'some_host_name.'))
+
+    def test_fetch_element_with_ovs_entry(self):
+        given_client = self.mock_client('topology_without_vhost_user')
+        self.mock_get_addresses_by_name(['10.237.214.247'])
+        given_network_topology = network_topology.NetworkTopology(
+            client=given_client)
+
+        element = given_network_topology._fetch_element_by_host(
+            'some_host_name.')
+
+        self.assertEqual('10.237.214.247', element.remote_ip)
+        self.assertIs(portbindings.VIF_TYPE_OVS, element.vif_type)
+
+    def test_fetch_element_with_vhost_user_entry(self):
+        given_client = self.mock_client('topology_with_vhost_user')
+        self.mock_get_addresses_by_name(['192.168.66.1'])
+        given_network_topology = network_topology.NetworkTopology(
+            client=given_client)
+
+        element = given_network_topology._fetch_element_by_host(
+            'some_host_name.')
+
+        self.assertEqual('192.168.66.1', element.remote_ip)
+        self.assertIs(portbindings.VIF_TYPE_VHOST_USER, element.vif_type)
+
+    def mock_get_addresses_by_name(self, ips):
+        return self.patch(
+            network_topology, 'utils',
+            mock.Mock(
+                get_addresses_by_name=mock.Mock(return_value=tuple(ips))))
+
+    def mock_client(self, topology_name):
+
+        cached_file_path = path.join(
+            path.dirname(__file__), topology_name + '.json')
+
+        with open(cached_file_path, 'rt') as fd:
+            topology = jsonutils.load(fd, encoding='utf-8')
+
+        mocked_client = mock.NonCallableMock(
+            specs=network_topology.NetworkTopologyClient)
+        mocked_client.get().json.return_value = topology
+
+        return mocked_client
+
+    @mock.patch.object(network_topology, 'cfg')
+    def test_get_vif_type(self, cfg):
+        # pylint: disable=unused-argument
+        given_port_context = mock.MagicMock(spec=api.PortContext)
+        given_topology = network_topology.NetworkTopology()
+
+        # when getting VIF type
+        vif_type = given_topology._get_vif_type(given_port_context)
+
+        # then VIF type is ovs
+        self.assertIs(vif_type, portbindings.VIF_TYPE_OVS)
+
+    def test_is_valid_segment(self):
+        """Validate the _check_segment method."""
+
+        # given driver and all network types
+        given_topology = network_topology.NetworkTopology()
+        all_network_types = [constants.TYPE_FLAT, constants.TYPE_GRE,
+                             constants.TYPE_LOCAL, constants.TYPE_VXLAN,
+                             constants.TYPE_VLAN, constants.TYPE_NONE]
+
+        # when checking segments network type
+        valid_types = {
+            network_type
+            for network_type in all_network_types
+            if given_topology._is_valid_segment(
+                {api.NETWORK_TYPE: network_type})}
+
+        # then true is returned only for valid network types
+        self.assertEqual({
+            constants.TYPE_LOCAL, constants.TYPE_GRE, constants.TYPE_VXLAN,
+            constants.TYPE_VLAN}, valid_types)
+
+    @mock.patch.object(network_topology.NetworkTopology, '_get_vif_type')
+    def test_bind_port_front_end(self, _get_vif_type):
+        given_front_end = mech_driver.OpenDaylightMechanismDriver()
+        given_port_context = self.given_port_context()
+        given_back_end = mech_driver.OpenDaylightDriver()
+        _get_vif_type.return_value = "EXPECTED_VIF_TYPE"
+        given_front_end.odl_drv = given_back_end
+
+        # when port is bound
+        given_front_end.bind_port(given_port_context)
+
+        # then vif type is got calling _get_vif_type
+        _get_vif_type.assert_called_once_with(given_port_context.host)
+
+        # then context binding is setup wit returned vif_type and valid
+        # segment api ID
+        given_port_context.set_binding.assert_called_once_with(
+            self.valid_segment[api.ID], 'EXPECTED_VIF_TYPE',
+            given_back_end.vif_details, status=n_constants.PORT_STATUS_ACTIVE)
+
+    def test_bind_port_back_end_with_vif_type_ovs(self):
+        self._test_bind_port(portbindings.VIF_TYPE_OVS)
+
+    def test_bind_port_back_end_with_vif_type_vhost_user(self):
+        self._test_bind_port(
+            portbindings.VIF_TYPE_VHOST_USER,
+            {'vhostuser_ovs_plug': True,
+             'vhostuser_socket': '/var/run/openvswitch/vhuCURRENT_CON',
+             'vhostuser_mode': 'client'})
+
+    def test_bind_port_without_valid_segment(self):
+        self.segments_to_bind = [self.invalid_segment]
+        self._test_bind_port(portbindings.VIF_TYPE_OVS)
+
+    def _test_bind_port(
+            self, given_vif_type, expected_additional_vif_details=None):
+        given_port_context = self.given_port_context()
+        given_topology = network_topology.NetworkTopology()
+        given_topology._get_vif_type = mock.Mock(return_value=given_vif_type)
+
+        # when port is bound
+        given_topology.bind_port(given_port_context)
+
+        if self.valid_segment in self.segments_to_bind:
+            # then vif type is got calling _get_vif_type
+            given_topology._get_vif_type.assert_called_once_with(
+                given_port_context.host)
+
+            expected_vif_details = dict(given_topology._vif_details)
+            if expected_additional_vif_details:
+                expected_vif_details.update(expected_additional_vif_details)
+
+            # then context binding is setup wit returned vif_type and valid
+            # segment api ID
+            given_port_context.set_binding.assert_called_once_with(
+                self.valid_segment[api.ID], given_vif_type,
+                expected_vif_details, status=n_constants.PORT_STATUS_ACTIVE)
+
+        else:
+            self.assertFalse(given_topology._get_vif_type.called)
+            self.assertFalse(given_port_context.set_binding.called)
+
+    def given_port_context(self):
+        # given NetworkContext
+        network = mock.MagicMock(spec=api.NetworkContext)
+
+        # given port context
+        return mock.MagicMock(
+            spec=driver_context.PortContext,
+            current={'id': 'CURRENT_CONTEXT_ID'},
+            segments_to_bind=self.segments_to_bind,
+            network=network)
+
+    def test_get_vif_type_without_vhost_user(self):
+        vif_type = self._test_get_vif_type(
+            'topology_without_vhost_user', ('10.237.214.247',))
+        self.assertIs(vif_type, portbindings.VIF_TYPE_OVS)
+
+    def test_get_vif_type_with_vhost_user(self):
+        vif_type = self._test_get_vif_type(
+            'topology_with_vhost_user', ('192.168.66.1',))
+        self.assertIs(vif_type, portbindings.VIF_TYPE_VHOST_USER)
+
+    def _test_get_vif_type(
+            self, mocked_topology_name, mocked_ip_addresses):
+        request = self.mock_request_network_topology(mocked_topology_name)
+        get_addresses_by_name = self.patch(
+            network_topology.utils, 'get_addresses_by_name',
+            return_value=mocked_ip_addresses)
+
+        given_topology = network_topology.NetworkTopology()
+
+        # when getting VIF type
+        vif_type = given_topology._get_vif_type('my_host_name')
+
+        # then IP addresses are fetched
+        get_addresses_by_name.assert_called_once_with('my_host_name')
+
+        # then topology has been fetched
+        request.assert_called_once_with(
+            method='GET', url=self.NETOWORK_TOPOLOGY_URL, data=None,
+            headers={'Content-Type': 'application/json'},
+            auth=('admin', 'admin'), timeout=5)
+
+        return vif_type
+
+    NETOWORK_TOPOLOGY_URL =\
+        'http://localhost:8181/'\
+        'restconf/operational/network-topology:network-topology/'
+
+    def mock_request_network_topology(self, file_name):
+        # patch given configuration
+        mocked_cfg = self.patch(network_topology, 'cfg')
+        mocked_cfg.CONF.ml2_odl.url =\
+            'http://localhost:8181/controller/nb/v2/neutron'
+        mocked_cfg.CONF.ml2_odl.username = 'admin'
+        mocked_cfg.CONF.ml2_odl.password = 'admin'
+        mocked_cfg.CONF.ml2_odl.timeout = 5
+
+        cached_file_path = path.join(
+            path.dirname(__file__), file_name + '.json')
+
+        if path.isfile(cached_file_path):
+            LOG.debug('Loading topology from file: %r', cached_file_path)
+            with open(cached_file_path, 'rt') as fd:
+                topology = jsonutils.load(fd, encoding='utf-8')
+
+        else:
+            LOG.debug(
+                'Getting topology from ODL: %r', self.NETOWORK_TOPOLOGY_URL)
+            request = requests.get(
+                self.NETOWORK_TOPOLOGY_URL, auth=('admin', 'admin'),
+                headers={'Content-Type': 'application/json'})
+            request.raise_for_status()
+
+            with open(cached_file_path, 'wt') as fd:
+                LOG.debug('Saving topology to file: %r', cached_file_path)
+                topology = request.json()
+                jsonutils.dump(
+                    topology, fd, sort_keys=True, indent=4,
+                    separators=(',', ': '))
+
+        mocked_request = self.patch(
+            mech_driver.odl_client.requests, 'request',
+            return_value=mock.MagicMock(
+                spec=requests.Response,
+                json=mock.MagicMock(return_value=topology)))
+
+        return mocked_request
+
+    def patch(self, target, name, *args, **kwargs):
+        context = mock.patch.object(target, name, *args, **kwargs)
+        patch = context.start()
+        self.addCleanup(context.stop)
+        return patch
+
+
+class TestNetworkTopologyClient(base.DietTestCase):
+
+    given_host = 'given.host'
+    given_port = 1234
+    given_url_with_port = 'http://{}:{}/'.format(
+        given_host, given_port)
+    given_url_without_port = 'http://{}/'.format(given_host)
+    given_username = 'GIVEN_USERNAME'
+    given_password = 'GIVEN_PASSWORD'
+    given_timeout = 20
+
+    def given_client(
+            self, url=None, username=None, password=None, timeout=None):
+        return network_topology.NetworkTopologyClient(
+            base_url=url or self.given_url_with_port,
+            username=username or self.given_username,
+            password=password or self.given_password,
+            timeout=timeout or self.given_timeout)
+
+    def test_constructor(self):
+        # When client is created
+        rest_client = network_topology.NetworkTopologyClient(
+            base_url=self.given_url_with_port,
+            username=self.given_username,
+            password=self.given_password,
+            timeout=self.given_timeout)
+
+        self.assertEqual(self.given_url_with_port, rest_client.base_url)
+        self.assertEqual(
+            (self.given_username, self.given_password), rest_client.auth)
+        self.assertEqual(self.given_timeout, rest_client.timeout)
+
+    def test_request_with_port(self):
+        # Given rest client and used 'requests' module
+        given_client = self.given_client()
+        mocked_requests_module = self.mocked_requests()
+
+        # When a request is performed
+        result = given_client.request(
+            'GIVEN_METHOD', 'given/path', 'GIVEN_DATA')
+
+        # Then request method is called
+        mocked_requests_module.request.assert_called_once_with(
+            auth=(self.given_username, self.given_password),
+            data='GIVEN_DATA', headers={'Content-Type': 'application/json'},
+            method='GIVEN_METHOD', timeout=self.given_timeout,
+            url='http://{}:{}/given/path'.format(
+                self.given_host, self.given_port))
+
+        # Then request method result is returned
+        self.assertIs(mocked_requests_module.request.return_value, result)
+
+    def test_request_without_port(self):
+        # Given rest client and used 'requests' module
+        given_client = self.given_client(url=self.given_url_without_port)
+        mocked_requests_module = self.mocked_requests()
+
+        # When a request is performed
+        result = given_client.request(
+            'GIVEN_METHOD', 'given/path', 'GIVEN_DATA')
+
+        # Then request method is called
+        mocked_requests_module.request.assert_called_once_with(
+            auth=(self.given_username, self.given_password),
+            data='GIVEN_DATA', headers={'Content-Type': 'application/json'},
+            method='GIVEN_METHOD', timeout=self.given_timeout,
+            url='http://{}/given/path'.format(self.given_host))
+
+        # Then request method result is returned
+        self.assertIs(mocked_requests_module.request.return_value, result)
+
+    def test_get(self):
+        # Given rest client and used 'requests' module
+        given_client = self.given_client()
+        mocked_requests_module = self.mocked_requests()
+
+        # When a request is performed
+        result = given_client.get('given/path', 'GIVEN_DATA')
+
+        # Then request method is called
+        mocked_requests_module.request.assert_called_once_with(
+            auth=(self.given_username, self.given_password),
+            data='GIVEN_DATA', headers={'Content-Type': 'application/json'},
+            method='GET', timeout=self.given_timeout,
+            url='http://{}:{}/given/path'.format(
+                self.given_host, self.given_port))
+
+        # Then request method result is returned
+        self.assertIs(mocked_requests_module.request.return_value, result)
+
+    def mocked_requests(self):
+        return self.patch(network_topology, 'requests')
+
+    def patch(self, target, name, *args, **kwargs):
+        context = mock.patch.object(target, name, *args, **kwargs)
+        mocked = context.start()
+        self.addCleanup(context.stop)
+        return mocked
+
+
+class TestNetworkingTopologyElement(base.DietTestCase):
+
+    def given_element(
+            self, has_datapath_type_netdev, support_vhost_user):
+        element = network_topology.NetworkTopologyElement()
+        element.has_datapath_type_netdev = has_datapath_type_netdev
+        element.support_vhost_user = support_vhost_user
+        return element
+
+    def test_vif_type_with_any_negative_value(self):
+        self.assertIs(
+            portbindings.VIF_TYPE_OVS, self.given_element(
+                has_datapath_type_netdev=False, support_vhost_user=False
+            ).vif_type)
+
+        self.assertIs(
+            portbindings.VIF_TYPE_OVS, self.given_element(
+                has_datapath_type_netdev=True, support_vhost_user=False
+            ).vif_type)
+
+        self.assertIs(
+            portbindings.VIF_TYPE_OVS, self.given_element(
+                has_datapath_type_netdev=False, support_vhost_user=True
+            ).vif_type)
+
+    def test_vif_type_with_all_positive_values(self):
+        self.assertIs(
+            portbindings.VIF_TYPE_VHOST_USER, self.given_element(
+                has_datapath_type_netdev=True, support_vhost_user=True
+            ).vif_type)

--- a/networking_odl/tests/unit/ml2/topology_with_vhost_user.json
+++ b/networking_odl/tests/unit/ml2/topology_with_vhost_user.json
@@ -1,0 +1,182 @@
+{
+    "network-topology": {
+        "topology": [
+            {
+                "topology-id": "flow:1"
+            },
+            {
+                "node": [
+                    {
+                        "node-id": "ovsdb://uuid/c805d82d-a5d8-419d-bc89-6e3713ff9f6c/bridge/br-int",
+                        "ovsdb:bridge-external-ids": [
+                            {
+                                "bridge-external-id-key": "opendaylight-iid",
+                                "bridge-external-id-value": "/network-topology:network-topology/network-topology:topology[network-topology:topology-id='ovsdb:1']/network-topology:node[network-topology:node-id='ovsdb://uuid/c805d82d-a5d8-419d-bc89-6e3713ff9f6c/bridge/br-int']"
+                            }
+                        ],
+                        "ovsdb:bridge-name": "br-int",
+                        "ovsdb:bridge-uuid": "e92ec02d-dba8-46d8-8047-680cab5ee8b0",
+                        "ovsdb:controller-entry": [
+                            {
+                                "controller-uuid": "8521e6df-54bd-48ac-a249-3bb810fd812c",
+                                "is-connected": false,
+                                "target": "tcp:192.168.66.1:6653"
+                            }
+                        ],
+                        "ovsdb:datapath-type": "ovsdb:datapath-type-netdev",
+                        "ovsdb:fail-mode": "ovsdb:ovsdb-fail-mode-secure",
+                        "ovsdb:managed-by": "/network-topology:network-topology/network-topology:topology[network-topology:topology-id='ovsdb:1']/network-topology:node[network-topology:node-id='ovsdb://uuid/c805d82d-a5d8-419d-bc89-6e3713ff9f6c']",
+                        "ovsdb:protocol-entry": [
+                            {
+                                "protocol": "ovsdb:ovsdb-bridge-protocol-openflow-13"
+                            }
+                        ],
+                        "termination-point": [
+                            {
+                                "ovsdb:interface-type": "ovsdb:interface-type-internal",
+                                "ovsdb:interface-uuid": "d21472db-5c3c-4b38-bf18-6ed3a32edff1",
+                                "ovsdb:name": "br-int",
+                                "ovsdb:port-uuid": "30adf59e-ff0d-478f-b37a-e37ea20dddd3",
+                                "tp-id": "br-int"
+                            }
+                        ]
+                    },
+                    {
+                        "node-id": "ovsdb://uuid/c805d82d-a5d8-419d-bc89-6e3713ff9f6c/bridge/br-nian1_1",
+                        "ovsdb:bridge-name": "br-nian1_1",
+                        "ovsdb:bridge-uuid": "243e01cb-e413-4615-a044-b254141e407d",
+                        "ovsdb:datapath-id": "00:00:ca:01:3e:24:15:46",
+                        "ovsdb:datapath-type": "ovsdb:datapath-type-netdev",
+                        "ovsdb:managed-by": "/network-topology:network-topology/network-topology:topology[network-topology:topology-id='ovsdb:1']/network-topology:node[network-topology:node-id='ovsdb://uuid/c805d82d-a5d8-419d-bc89-6e3713ff9f6c']",
+                        "termination-point": [
+                            {
+                                "ovsdb:interface-type": "ovsdb:interface-type-internal",
+                                "ovsdb:interface-uuid": "45184fd2-31eb-4c87-a071-2d64a0893662",
+                                "ovsdb:name": "br-nian1_1",
+                                "ovsdb:ofport": 65534,
+                                "ovsdb:port-uuid": "f5952c1b-6b6d-4fd2-b2cd-201b8c9e0779",
+                                "tp-id": "br-nian1_1"
+                            }
+                        ]
+                    },
+                    {
+                        "node-id": "ovsdb://uuid/c805d82d-a5d8-419d-bc89-6e3713ff9f6c/bridge/br-ex",
+                        "ovsdb:bridge-external-ids": [
+                            {
+                                "bridge-external-id-key": "bridge-id",
+                                "bridge-external-id-value": "br-ex"
+                            }
+                        ],
+                        "ovsdb:bridge-name": "br-ex",
+                        "ovsdb:bridge-other-configs": [
+                            {
+                                "bridge-other-config-key": "disable-in-band",
+                                "bridge-other-config-value": "true"
+                            }
+                        ],
+                        "ovsdb:bridge-uuid": "43f7768e-c2f9-4ae7-8099-8aee5a17add7",
+                        "ovsdb:datapath-id": "00:00:8e:76:f7:43:e7:4a",
+                        "ovsdb:datapath-type": "ovsdb:datapath-type-netdev",
+                        "ovsdb:managed-by": "/network-topology:network-topology/network-topology:topology[network-topology:topology-id='ovsdb:1']/network-topology:node[network-topology:node-id='ovsdb://uuid/c805d82d-a5d8-419d-bc89-6e3713ff9f6c']",
+                        "termination-point": [
+                            {
+                                "ovsdb:interface-type": "ovsdb:interface-type-internal",
+                                "ovsdb:interface-uuid": "bdec1830-e6a5-4476-adff-569c455adb33",
+                                "ovsdb:name": "br-ex",
+                                "ovsdb:ofport": 65534,
+                                "ovsdb:port-uuid": "7ba5939b-ff13-409d-86de-67556021ddff",
+                                "tp-id": "br-ex"
+                            }
+                        ]
+                    },
+                    {
+                        "node-id": "ovsdb://uuid/c805d82d-a5d8-419d-bc89-6e3713ff9f6c",
+                        "ovsdb:connection-info": {
+                            "local-ip": "192.168.66.1",
+                            "local-port": 6640,
+                            "remote-ip": "192.168.66.1",
+                            "remote-port": 41817
+                        },
+                        "ovsdb:datapath-type-entry": [
+                            {
+                                "datapath-type": "ovsdb:datapath-type-netdev"
+                            },
+                            {
+                                "datapath-type": "ovsdb:datapath-type-system"
+                            }
+                        ],
+                        "ovsdb:interface-type-entry": [
+                            {
+                                "interface-type": "ovsdb:interface-type-ipsec-gre"
+                            },
+                            {
+                                "interface-type": "ovsdb:interface-type-gre"
+                            },
+                            {
+                                "interface-type": "ovsdb:interface-type-gre64"
+                            },
+                            {
+                                "interface-type": "ovsdb:interface-type-dpdkr"
+                            },
+                            {
+                                "interface-type": "ovsdb:interface-type-vxlan"
+                            },
+                            {
+                                "interface-type": "ovsdb:interface-type-dpdkvhostuser"
+                            },
+                            {
+                                "interface-type": "ovsdb:interface-type-tap"
+                            },
+                            {
+                                "interface-type": "ovsdb:interface-type-geneve"
+                            },
+                            {
+                                "interface-type": "ovsdb:interface-type-dpdk"
+                            },
+                            {
+                                "interface-type": "ovsdb:interface-type-internal"
+                            },
+                            {
+                                "interface-type": "ovsdb:interface-type-system"
+                            },
+                            {
+                                "interface-type": "ovsdb:interface-type-lisp"
+                            },
+                            {
+                                "interface-type": "ovsdb:interface-type-patch"
+                            },
+                            {
+                                "interface-type": "ovsdb:interface-type-ipsec-gre64"
+                            },
+                            {
+                                "interface-type": "ovsdb:interface-type-stt"
+                            }
+                        ],
+                        "ovsdb:managed-node-entry": [
+                            {
+                                "bridge-ref": "/network-topology:network-topology/network-topology:topology[network-topology:topology-id='ovsdb:1']/network-topology:node[network-topology:node-id='ovsdb://uuid/c805d82d-a5d8-419d-bc89-6e3713ff9f6c/bridge/br-ex']"
+                            },
+                            {
+                                "bridge-ref": "/network-topology:network-topology/network-topology:topology[network-topology:topology-id='ovsdb:1']/network-topology:node[network-topology:node-id='ovsdb://uuid/c805d82d-a5d8-419d-bc89-6e3713ff9f6c/bridge/br-int']"
+                            },
+                            {
+                                "bridge-ref": "/network-topology:network-topology/network-topology:topology[network-topology:topology-id='ovsdb:1']/network-topology:node[network-topology:node-id='ovsdb://uuid/c805d82d-a5d8-419d-bc89-6e3713ff9f6c/bridge/br-nian1_1']"
+                            }
+                        ],
+                        "ovsdb:openvswitch-other-configs": [
+                            {
+                                "other-config-key": "local_ip",
+                                "other-config-value": "192.168.66.1"
+                            },
+                            {
+                                "other-config-key": "pmd-cpu-mask",
+                                "other-config-value": "400004"
+                            }
+                        ]
+                    }
+                ],
+                "topology-id": "ovsdb:1"
+            }
+        ]
+    }
+}

--- a/networking_odl/tests/unit/ml2/topology_without_vhost_user.json
+++ b/networking_odl/tests/unit/ml2/topology_without_vhost_user.json
@@ -1,0 +1,171 @@
+{
+    "network-topology": {
+        "topology": [
+            {
+                "topology-id": "flow:1"
+            },
+            {
+                "node": [
+                    {
+                        "node-id": "ovsdb://uuid/c4ad780f-8f91-4fa4-804e-dd16beb191e2/bridge/br-ex",
+                        "ovsdb:bridge-external-ids": [
+                            {
+                                "bridge-external-id-key": "bridge-id",
+                                "bridge-external-id-value": "br-ex"
+                            }
+                        ],
+                        "ovsdb:bridge-name": "br-ex",
+                        "ovsdb:bridge-other-configs": [
+                            {
+                                "bridge-other-config-key": "disable-in-band",
+                                "bridge-other-config-value": "true"
+                            }
+                        ],
+                        "ovsdb:bridge-uuid": "4ba78705-3ac2-4e36-a2e1-32f1647d97a7",
+                        "ovsdb:datapath-id": "00:00:06:87:a7:4b:36:4e",
+                        "ovsdb:datapath-type": "ovsdb:datapath-type-netdev",
+                        "ovsdb:managed-by": "/network-topology:network-topology/network-topology:topology[network-topology:topology-id='ovsdb:1']/network-topology:node[network-topology:node-id='ovsdb://uuid/c4ad780f-8f91-4fa4-804e-dd16beb191e2']",
+                        "termination-point": [
+                            {
+                                "ovsdb:interface-external-ids": [
+                                    {
+                                        "external-id-key": "iface-id",
+                                        "external-id-value": "c44000c6-f199-4609-9325-afd8c72b6777"
+                                    },
+                                    {
+                                        "external-id-key": "iface-status",
+                                        "external-id-value": "active"
+                                    },
+                                    {
+                                        "external-id-key": "attached-mac",
+                                        "external-id-value": "fa:16:3e:a0:d5:49"
+                                    }
+                                ],
+                                "ovsdb:interface-type": "ovsdb:interface-type-internal",
+                                "ovsdb:interface-uuid": "c1081aa3-607f-404e-a71e-ea1dd334b263",
+                                "ovsdb:name": "qg-c44000c6-f1",
+                                "ovsdb:ofport": 1,
+                                "ovsdb:port-uuid": "1a2ef41e-4836-420c-977f-7a662c7abe62",
+                                "tp-id": "qg-c44000c6-f1"
+                            },
+                            {
+                                "ovsdb:interface-type": "ovsdb:interface-type-internal",
+                                "ovsdb:interface-uuid": "54439f6a-7a88-4cf6-84b7-0645642618f9",
+                                "ovsdb:name": "br-ex",
+                                "ovsdb:ofport": 65534,
+                                "ovsdb:port-uuid": "9bf4c1ab-d111-479d-84ab-1874f166153b",
+                                "tp-id": "br-ex"
+                            }
+                        ]
+                    },
+                    {
+                        "node-id": "ovsdb://uuid/c4ad780f-8f91-4fa4-804e-dd16beb191e2",
+                        "ovsdb:connection-info": {
+                            "local-ip": "10.237.214.247",
+                            "local-port": 6640,
+                            "remote-ip": "10.237.214.247",
+                            "remote-port": 43247
+                        },
+                        "ovsdb:managed-node-entry": [
+                            {
+                                "bridge-ref": "/network-topology:network-topology/network-topology:topology[network-topology:topology-id='ovsdb:1']/network-topology:node[network-topology:node-id='ovsdb://uuid/c4ad780f-8f91-4fa4-804e-dd16beb191e2/bridge/br-int']"
+                            },
+                            {
+                                "bridge-ref": "/network-topology:network-topology/network-topology:topology[network-topology:topology-id='ovsdb:1']/network-topology:node[network-topology:node-id='ovsdb://uuid/c4ad780f-8f91-4fa4-804e-dd16beb191e2/bridge/br-ex']"
+                            }
+                        ],
+                        "ovsdb:openvswitch-external-ids": [
+                            {
+                                "external-id-key": "system-id",
+                                "external-id-value": "c4dcfd6c-8f0e-43a6-9cf5-d2a0c37f5c52"
+                            }
+                        ],
+                        "ovsdb:openvswitch-other-configs": [
+                            {
+                                "other-config-key": "local_ip",
+                                "other-config-value": "10.237.214.247"
+                            },
+                            {
+                                "other-config-key": "provider_mappings",
+                                "other-config-value": "default:ens786f0"
+                            }
+                        ],
+                        "ovsdb:ovs-version": "2.3.2"
+                    },
+                    {
+                        "node-id": "ovsdb://uuid/c4ad780f-8f91-4fa4-804e-dd16beb191e2/bridge/br-int",
+                        "ovsdb:bridge-external-ids": [
+                            {
+                                "bridge-external-id-key": "bridge-id",
+                                "bridge-external-id-value": "br-int"
+                            }
+                        ],
+                        "ovsdb:bridge-name": "br-int",
+                        "ovsdb:bridge-uuid": "d3acbe7f-cdab-4ef1-80b8-68e5db3b3b7b",
+                        "ovsdb:datapath-id": "00:00:7e:be:ac:d3:f1:4e",
+                        "ovsdb:datapath-type": "ovsdb:datapath-type-system",
+                        "ovsdb:managed-by": "/network-topology:network-topology/network-topology:topology[network-topology:topology-id='ovsdb:1']/network-topology:node[network-topology:node-id='ovsdb://uuid/c4ad780f-8f91-4fa4-804e-dd16beb191e2']",
+                        "termination-point": [
+                            {
+                                "ovsdb:interface-type": "ovsdb:interface-type-internal",
+                                "ovsdb:interface-uuid": "8164bb4f-2b8c-4405-b8de-4b6b776baa27",
+                                "ovsdb:name": "br-int",
+                                "ovsdb:ofport": 65534,
+                                "ovsdb:port-uuid": "c34e1347-6757-4770-a05e-66cfb4b65167",
+                                "tp-id": "br-int"
+                            },
+                            {
+                                "ovsdb:interface-external-ids": [
+                                    {
+                                        "external-id-key": "iface-id",
+                                        "external-id-value": "1d5780fc-da03-4c98-8082-089d70cb65e3"
+                                    },
+                                    {
+                                        "external-id-key": "iface-status",
+                                        "external-id-value": "active"
+                                    },
+                                    {
+                                        "external-id-key": "attached-mac",
+                                        "external-id-value": "fa:16:3e:ee:3e:36"
+                                    }
+                                ],
+                                "ovsdb:interface-type": "ovsdb:interface-type-internal",
+                                "ovsdb:interface-uuid": "00d8d482-abf9-4459-8cb1-9c8e80df4943",
+                                "ovsdb:name": "tap1d5780fc-da",
+                                "ovsdb:ofport": 1,
+                                "ovsdb:port-uuid": "743a236a-a34c-4084-a5ed-8dac56371ca8",
+                                "tp-id": "tap1d5780fc-da"
+                            },
+                            {
+                                "ovsdb:interface-external-ids": [
+                                    {
+                                        "external-id-key": "iface-id",
+                                        "external-id-value": "674fd914-74c0-4065-a88a-929919446555"
+                                    },
+                                    {
+                                        "external-id-key": "iface-status",
+                                        "external-id-value": "active"
+                                    },
+                                    {
+                                        "external-id-key": "attached-mac",
+                                        "external-id-value": "fa:16:3e:62:0c:d3"
+                                    }
+                                ],
+                                "ovsdb:interface-type": "ovsdb:interface-type-internal",
+                                "ovsdb:interface-uuid": "41bde142-61bc-4297-a39d-8b0ee86a0731",
+                                "ovsdb:name": "qr-674fd914-74",
+                                "ovsdb:ofport": 2,
+                                "ovsdb:port-uuid": "1c505a53-ccfd-4745-9526-211016d9cbb3",
+                                "tp-id": "qr-674fd914-74"
+                            }
+                        ]
+                    }
+                ],
+                "topology-id": "ovsdb:1"
+            },
+            {
+                "topology-id": "netvirt:1"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Over the past six months ovs and odl have been extended to report
the supported port types available on the vswitch.
This change extends the bind_port implementation to consult the supported
port types of the vswitch on the selected compute host when selecting the
VIF_TYPE to bind.

Change-Id: Ib97c2d2e1e2e1cd536bc27ac54a8f27a5963e883
Closes-Bug: #1477611
