### PR TITLE
Enable vhost-user ports on supported platforms.

### DIFF
--- a/devstack/README.rst
+++ b/devstack/README.rst
@@ -63,3 +63,41 @@
      enable_plugin networking-odl http://git.openstack.org/openstack/networking-odl
      SKIP_OVS_INSTALL=True
      Q_ML2_PLUGIN_MECHANISM_DRIVERS=opendaylight
+
+10. Configure port binding
+
+The network port binding for spawned VMs can be implemented by more (virtual)
+switch implementations. The way network ports are binded to virtual network
+can be restricted configuring a list of knwon VIF types. Known valid vif types
+are for example 'ovs' and 'vhostuser'. You can specify this ordered list by
+editing 'ODL_VALID_VIF_TYPES' variable in the local.conf file::
+
+     > cat local.conf
+     [[local|localrc]]
+     ODL_VALID_VIF_TYPES=vhostuser,ovs
+
+Port binding is performed detecting VIF types supported by compute host where
+new virtual machine is going to be spawn. Host capabilities are inferred by
+parsing network topology fetched from OpenDayligh using following URL:
+
+http://<odl-server-ip>:<port>/restconf/operational/network-topology:network-topology
+
+where odl-server-ip could be for example 192.168.2.10 and port 8087. This URL
+can be changed editing local.conf::
+
+     > cat local.conf
+     [[local|localrc]]
+     ODL_NETWORK_TOPOLOGY_URL="http://192.168.2.10:8087/restconf/operational/network-topology:network-topology"
+
+By the default above URL is obtained from the URL networking-odl is configured
+to connect to OpenDaylight north bound.
+
+Network topology is parsed to detect supported VIF type by a list of pluggable
+network topology parsers. These parsers are created starting from a list of
+know class names implementing NetworkTopologyParser interface.
+You can specify this ordered list by editing 'ODL_NETWORK_TOPOLOGY_PARSERS'
+variable in the local.conf file::
+
+     > cat local.conf
+     [[local|localrc]]
+     ODL_NETWORK_TOPOLOGY_PARSERS=networking_odl.ml2.ovsdb_topology:OvsdbNetworkTopologyParser

--- a/devstack/entry_points
+++ b/devstack/entry_points
@@ -127,6 +127,9 @@ function configure_neutron_odl {
     populate_ml2_config /$Q_PLUGIN_CONF_FILE ml2_odl url=$ODL_ENDPOINT
     populate_ml2_config /$Q_PLUGIN_CONF_FILE ml2_odl username=$ODL_USERNAME
     populate_ml2_config /$Q_PLUGIN_CONF_FILE ml2_odl password=$ODL_PASSWORD
+    populate_ml2_config /$Q_PLUGIN_CONF_FILE ml2_odl valid_vif_types=$ODL_VALID_VIF_TYPES
+    populate_ml2_config /$Q_PLUGIN_CONF_FILE ml2_odl network_topology_url=$ODL_NETWORK_TOPOLOGY_URL
+    populate_ml2_config /$Q_PLUGIN_CONF_FILE ml2_odl network_topology_parsers=$ODL_NETWORK_TOPOLOGY_PARSERS
 }
 
 function configure_neutron_odl_lightweight_testing {

--- a/networking_odl/common/client.py
+++ b/networking_odl/common/client.py
@@ -27,7 +27,7 @@ cfg.CONF.import_group('ml2_odl', 'networking_odl.common.config')
 class OpenDaylightRestClient(object):
 
     @classmethod
-    def create_client(cls):
+    def create_client(cls, **kwargs):
         if cfg.CONF.ml2_odl.enable_lightweight_testing:
             LOG.debug("ODL lightweight testing is enabled, ",
                       "returning a OpenDaylightLwtClient instance")
@@ -40,7 +40,8 @@ class OpenDaylightRestClient(object):
             cfg.CONF.ml2_odl.url,
             cfg.CONF.ml2_odl.username,
             cfg.CONF.ml2_odl.password,
-            cfg.CONF.ml2_odl.timeout)
+            cfg.CONF.ml2_odl.timeout,
+            **kwargs)
 
     def __init__(self, url, username, password, timeout):
         self.url = url

--- a/networking_odl/common/config.py
+++ b/networking_odl/common/config.py
@@ -34,6 +34,19 @@ odl_opts = [
     cfg.BoolOpt('enable_lightweight_testing',
                 default=False,
                 help='Test without real ODL'),
+
+    # Port binding options
+    cfg.StrOpt(
+        name='valid_vif_types',
+        help=_("List of VIF types valid for port binding: ovs, "
+               "vhostuser, etc.")),
+    cfg.StrOpt(
+        'network_topology_url',
+        help=_("Http URL to fetch network topology from ODL.")),
+    cfg.StrOpt(
+        name='network_topology_parsers',
+        help=_("List of knwon network topology parser implementation "
+               "classes.")),
 ]
 
 cfg.CONF.register_opts(odl_opts, "ml2_odl")

--- a/networking_odl/ml2/mech_driver.py
+++ b/networking_odl/ml2/mech_driver.py
@@ -242,8 +242,8 @@ class OpenDaylightDriver(object):
         self.client = odl_client.OpenDaylightRestClient.create_client()
         self.sec_handler = odl_call.OdlSecurityGroupsHandler(self)
         self.vif_details = {portbindings.CAP_PORT_FILTER: True}
-        self._network_topology = network_topology.NetworkTopologyManager(
-            vif_details=self.vif_details)
+        self._network_topology = network_topology.NetworkTopologyManager.\
+            create_topology_manager(vif_details=self.vif_details)
 
     def synchronize(self, operation, object_type, context):
         """Synchronize ODL with Neutron following a configuration change."""

--- a/networking_odl/ml2/mech_driver_v2.py
+++ b/networking_odl/ml2/mech_driver_v2.py
@@ -43,7 +43,8 @@ class OpenDaylightMechanismDriver(api.MechanismDriver):
         self.sg_handler = callback.OdlSecurityGroupsHandler(self)
         self.vif_details = {portbindings.CAP_PORT_FILTER: True}
         self.journal = journal.OpendaylightJournalThread()
-        self._network_topology = network_topology.NetworkTopologyManager()
+        self._network_topology = network_topology.NetworkTopologyManager.\
+            create_topology_manager(vif_details=self.vif_details)
 
     @journal.call_thread_on_end
     def create_network_precommit(self, context):

--- a/networking_odl/ml2/ovsdb_topology.py
+++ b/networking_odl/ml2/ovsdb_topology.py
@@ -34,6 +34,8 @@ LOG = log.getLogger(__name__)
 
 class OvsdbNetworkTopologyParser(network_topology.NetworkTopologyParser):
 
+    supported_vif_types = ['vhostuser', 'ovs']
+
     def new_element(self, uuid):
         return OvsdbNetworkTopologyElement(uuid=uuid)
 


### PR DESCRIPTION
Over the past six months ovs and odl have been extended to report
the supported port types available on the virtual switch.
This change extends the bind_port implementation to consult the supported
port types of the virtual switch on the selected compute host when selecting
the VIF_TYPE to bind.

Change-Id: Ib97c2d2e1e2e1cd536bc27ac54a8f27a5963e883
Closes-Bug: #1477611
