### PR TITLE
Make valid VIF types configurable

### DIFF
--- a/devstack/README.rst
+++ b/devstack/README.rst
@@ -63,3 +63,15 @@
      enable_plugin networking-odl http://git.openstack.org/openstack/networking-odl
      SKIP_OVS_INSTALL=True
      Q_ML2_PLUGIN_MECHANISM_DRIVERS=opendaylight
+
+10. Configure port binding
+
+The network port binding for spawned VMs can be implemented by more (virtual)
+switch implementations. The way network ports are binded to virtual network
+can be restricted configuring a list of knwon VIF types. Known valid vif types
+are for example 'ovs' and 'vhostuser'. You can specify this ordered list by
+editing 'ODL_VALID_VIF_TYPES' variable in the local.conf file::
+
+     > cat local.conf
+     [[local|localrc]]
+     ODL_VALID_VIF_TYPES=vhostuser,ovs

--- a/devstack/entry_points
+++ b/devstack/entry_points
@@ -127,6 +127,8 @@ function configure_neutron_odl {
     populate_ml2_config /$Q_PLUGIN_CONF_FILE ml2_odl url=$ODL_ENDPOINT
     populate_ml2_config /$Q_PLUGIN_CONF_FILE ml2_odl username=$ODL_USERNAME
     populate_ml2_config /$Q_PLUGIN_CONF_FILE ml2_odl password=$ODL_PASSWORD
+    populate_ml2_config /$Q_PLUGIN_CONF_FILE ml2_odl\
+        valid_vif_types=$ODL_VALID_VIF_TYPES
 }
 
 function configure_neutron_odl_lightweight_testing {

--- a/networking_odl/common/config.py
+++ b/networking_odl/common/config.py
@@ -34,6 +34,9 @@ odl_opts = [
     cfg.BoolOpt('enable_lightweight_testing',
                 default=False,
                 help='Test without real ODL'),
+    cfg.StrOpt('valid_vif_types',
+               help=_("List of valid VIF types for port binding like 'ovs', "
+                      "'vhostuser', etc.")),
 ]
 
 cfg.CONF.register_opts(odl_opts, "ml2_odl")

--- a/networking_odl/ml2/mech_driver.py
+++ b/networking_odl/ml2/mech_driver.py
@@ -242,8 +242,9 @@ class OpenDaylightDriver(object):
         self.client = odl_client.OpenDaylightRestClient.create_client()
         self.sec_handler = odl_call.OdlSecurityGroupsHandler(self)
         self.vif_details = {portbindings.CAP_PORT_FILTER: True}
-        self._network_topology = network_topology.NetworkTopologyManager(
-            vif_details=self.vif_details)
+        self._network_topology =\
+            network_topology.NetworkTopologyManager.create_topology_manager(
+                vif_details=self.vif_details)
 
     def synchronize(self, operation, object_type, context):
         """Synchronize ODL with Neutron following a configuration change."""

--- a/networking_odl/ml2/mech_driver_v2.py
+++ b/networking_odl/ml2/mech_driver_v2.py
@@ -43,7 +43,9 @@ class OpenDaylightMechanismDriver(api.MechanismDriver):
         self.sg_handler = callback.OdlSecurityGroupsHandler(self)
         self.vif_details = {portbindings.CAP_PORT_FILTER: True}
         self.journal = journal.OpendaylightJournalThread()
-        self._network_topology = network_topology.NetworkTopologyManager()
+        self._network_topology =\
+            network_topology.NetworkTopologyManager.create_topology_manager(
+                vif_details=self.vif_details)
 
     @journal.call_thread_on_end
     def create_network_precommit(self, context):

--- a/networking_odl/tests/unit/ml2/test_networking_topology.py
+++ b/networking_odl/tests/unit/ml2/test_networking_topology.py
@@ -159,12 +159,12 @@ class TestNetworkTopologyManager(base.DietTestCase):
 
         given_client = self.mock_client('ovs_topology.json')
         self.mock_get_addresses_by_name(['127.0.0.1', '10.237.214.247'])
-        given_network_topology = network_topology.NetworkTopologyManager(
+        given_manager = network_topology.NetworkTopologyManager(
             vif_details={'some': 'detail'},
             client=given_client)
         self.patch(
-            network_topology, 'NetworkTopologyManager',
-            return_value=given_network_topology)
+            network_topology.NetworkTopologyManager,
+            'create_topology_manager', return_value=given_manager)
 
         given_driver = mech_driver.OpenDaylightMechanismDriver()
         given_driver.odl_drv = mech_driver.OpenDaylightDriver()
@@ -183,12 +183,12 @@ class TestNetworkTopologyManager(base.DietTestCase):
 
         given_client = self.mock_client('vhostuser_topology.json')
         self.mock_get_addresses_by_name(['127.0.0.1', '192.168.66.1'])
-        given_network_topology = network_topology.NetworkTopologyManager(
+        given_manager = network_topology.NetworkTopologyManager(
             vif_details={'some': 'detail'},
             client=given_client)
         self.patch(
-            network_topology, 'NetworkTopologyManager',
-            return_value=given_network_topology)
+            network_topology.NetworkTopologyManager,
+            'create_topology_manager', return_value=given_manager)
 
         given_driver = mech_driver.OpenDaylightMechanismDriver()
         given_driver.odl_drv = mech_driver.OpenDaylightDriver()


### PR DESCRIPTION
Port binding allow to specify the list of valid VIF types to be used
for port binding. This allow to restrict selection to a subset and to
give preference hints to ML2 drivers.

This list of strings has to be optionally read from driver
configuration file and from local.conf.

NOTE: this change was split from below change to make it
lighter for code review:

https://review.openstack.org/#/c/273390/

Change-Id: Ifce3ff93527976f7469e648cedb49d015c1ba08b
Closes-Bug: #1552172
